### PR TITLE
fix(typo): fix some typo mistakes

### DIFF
--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -1,0 +1,21 @@
+name: Build and Test
+
+on:
+  push:
+    branches: ["main"]
+  pull_request:
+    branches: ["main"]
+
+env:
+  CARGO_TERM_COLOR: always
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+
+    steps:
+      - uses: actions/checkout@v4
+      - name: Build
+        run: cargo build --verbose
+      - name: Run tests
+        run: cargo test --verbose

--- a/onebot_v11/src/api/payload.rs
+++ b/onebot_v11/src/api/payload.rs
@@ -4,141 +4,146 @@ use serde::{Deserialize, Serialize};
 
 #[derive(Debug, Clone, PartialEq, Eq, ApiDataDerive)]
 pub enum ApiPayload {
-    // 发送私聊消息
+    /// 发送私聊消息
     SendPrivateMsg(SendPrivateMsg),
-    // 发送群消息
+    /// 发送群消息
     SendGroupMsg(SendGroupMsg),
-    // 发送消息
+    /// 发送消息
     SendMsg(SendMsg),
-    // 撤回消息
+    /// 撤回消息
     DeleteMsg(DeleteMsg),
-    // 获取消息
+    /// 获取消息
     GetMsg(GetMsg),
-    // 获取合并转发消息
+    /// 获取合并转发消息
     GetForwardMsg(GetForwardMsg),
-    // 发送好友赞
+    /// 发送好友赞
     SendLike(SendLike),
-    // 群组踢人
+    /// 群组踢人
     SetGroupKick(SetGroupKick),
-    // 群组禁言
+    /// 群组禁言
     SetGroupBan(SetGroupBan),
-    // 群组匿名用户禁言
+    /// 群组匿名用户禁言
     SetGroupAnonymousBan(SetGroupAnonymousBan),
-    // 群组全员禁言
+    /// 群组全员禁言
     SetGroupWholeBan(SetGroupWholeBan),
-    // 群组设置管理员
+    /// 群组设置管理员
     SetGroupAdmin(SetGroupAdmin),
-    // 群组匿名
+    /// 群组匿名
     SetGroupAnonymous(SetGroupAnonymous),
-    // 设置群名片（群备注）
+    /// 设置群名片（群备注）
     SetGroupCard(SetGroupCard),
-    // 设置群名
+    /// 设置群名
     SetGroupName(SetGroupName),
-    // 退出群组
+    /// 退出群组
     SetGroupLeave(SetGroupLeave),
-    // 设置群组专属头衔
+    /// 设置群组专属头衔
     SetGroupSpecialTitle(SetGroupSpecialTitle),
-    // 处理加好友请求
+    /// 处理加好友请求
     SetFriendAddRequest(SetFriendAddRequest),
-    // 处理加群请求／邀请
+    /// 处理加群请求／邀请
     SetGroupAddRequest(SetGroupAddRequest),
-    // 获取登录号信息
+    /// 获取登录号信息
     GetLoginInfo(GetLoginInfo),
-    // 获取陌生人信息
+    /// 获取陌生人信息
     GetStrangerInfo(GetStrangerInfo),
-    // 获取好友列表
+    /// 获取好友列表
     GetFriendList(GetFriendList),
-    // 获取群信息
+    /// 获取群信息
     GetGroupInfo(GetGroupInfo),
-    // 获取群列表
+    /// 获取群列表
     GetGroupList(GetGroupList),
-    // 获取群成员信息
+    /// 获取群成员信息
     GetGroupMemberInfo(GetGroupMemberInfo),
-    // 获取群成员列表
+    /// 获取群成员列表
     GetGroupMemberList(GetGroupMemberList),
-    // 获取群荣誉信息
+    /// 获取群荣誉信息
     GetGroupHonorInfo(GetGroupHonorInfo),
-    // 获取 Cookies
+    /// 获取 Cookies
     GetCookies(GetCookies),
-    // 获取 CSRF Token
+    /// 获取 CSRF Token
     GetCsrfToken(GetCsrfToken),
-    // 获取 QQ 相关接口凭证
+    /// 获取 QQ 相关接口凭证
     GetCredentials(GetCredentials),
-    // 获取语音
+    /// 获取语音
     GetRecord(GetRecord),
-    // 获取图片
+    /// 获取图片
     GetImage(GetImage),
-    // 检查是否可以发送图片
+    /// 检查是否可以发送图片
     CanSendImage(CanSendImage),
-    // 检查是否可以发送语音
+    /// 检查是否可以发送语音
     CanSendRecord(CanSendRecord),
-    // 获取运行状态
+    /// 获取运行状态
     GetStatus(GetStatus),
-    // 获取版本信息
+    /// 获取版本信息
     GetVersionInfo(GetVersionInfo),
-    // 重启 OneBot 实现
+    /// 重启 OneBot 实现
     SetRestart(SetRestart),
-    // 清理 OneBot 实现缓存
+    /// 清理 OneBot 实现缓存
     CleanCache(CleanCache),
-    // NapCat/llonebot扩展
 
-    // 设置头像
+    // NapCat / llOneBot扩展
+    /// 设置头像
     SetQQAvatar(SetQQAvatar),
-    // 获取群系统通知
+    /// 获取群系统通知
     GetGroupSystemMsg(GetGroupSystemMsg),
-    // 下载群文件或私聊文件
+    /// 下载群文件或私聊文件
     GetFile(GetFile),
-    // 转发单条消息给好友
+    /// 转发单条消息给好友
     ForwardFriendSingleMsg(ForwardFriendSingleMsg),
-    // 转发单条消息给群
+    /// 转发单条消息给群
     ForwardGroupSingleMsg(ForwardGroupSingleMsg),
-    // 设置表情回应
+    /// 设置表情回应
     SetMsgEmojiLike(SetMsgEmojiLike),
-    // 标记私聊消息为已读
+    /// 标记私聊消息为已读
     MarkPrivateMsgAsRead(MarkPrivateMsgAsRead),
-    // 标记群消息为已读
+    /// 标记群消息为已读
     MarkGroupMsgAsRead(MarkGroupMsgAsRead),
-    // 获取官方bot qq号范围
+    /// 获取官方bot qq号范围
     GetRobotUinRange(GetRobotUinRange),
-    // 设置自身在线状态
+    /// 设置自身在线状态
     SetOnlineStatus(SetOnlineStatus),
-    // 获取好友分类列表
+    /// 获取好友分类列表
     GetFriendsWithCategory(GetFriendsWithCategory),
-    // 获取群文件数量
+    /// 获取群文件数量
     GetGroupFileCount(GetGroupFileCount),
-    // 获取群文件列表
+    /// 获取群文件列表
     GetGroupFileList(GetGroupFileList),
-    // 创建群文件夹
+    /// 创建群文件夹
     SetGroupFileFolder(SetGroupFileFolder),
-    // 删除群文件
+    /// 删除群文件
     DelGroupFile(DelGroupFile),
-    // 删除群文件夹
+    /// 删除群文件夹
     DelGroupFileFolder(DelGroupFileFolder),
 
-    // NapCat gocq拓展
-
-    // 合并转发消息给群聊
+    /// NapCat / GoCq 拓展
+    /// 合并转发消息给群聊
     SendGroupForwardMsg(SendGroupForwardMsg),
-    // 合并转发消息给好友
+    /// 合并转发消息给好友
     SendPrivateForwardMsg(SendPrivateForwardMsg),
 }
 
-// 发送私聊消息结构体
+/// 发送私聊消息结构体
 #[endpoint("send_private_msg")]
 #[derive(Serialize, Deserialize, Debug, Clone, PartialEq, Eq)]
 pub struct SendPrivateMsg {
-    pub user_id: i64,                 // 对方 QQ 号
-    pub message: Vec<MessageSegment>, // 要发送的内容
-    pub auto_escape: bool, // 消息内容是否作为纯文本发送（即不解析 CQ 码），只在 message 字段是字符串时有效
+    /// 对方 QQ 号
+    pub user_id: i64,
+    /// 要发送的内容
+    pub message: Vec<MessageSegment>,
+    /// 消息内容是否作为纯文本发送（即不解析 CQ 码），只在 message 字段是字符串时有效
+    pub auto_escape: bool,
 }
 
-// 发送群消息结构体
+/// 发送群消息结构体
 #[endpoint("send_group_msg")]
 #[derive(Serialize, Deserialize, Debug, Clone, PartialEq, Eq)]
 pub struct SendGroupMsg {
-    pub group_id: i64,                // 群号
-    pub message: Vec<MessageSegment>, // 要发送的消息内容
-    pub auto_escape: bool,            // 消息内容是否作为纯文本发送（不解析 CQ 码）
+    /// 群号
+    pub group_id: i64,
+    /// 要发送的消息内容
+    pub message: Vec<MessageSegment>,
+    /// 消息内容是否作为纯文本发送（不解析 CQ 码）
+    pub auto_escape: bool,
 }
 
 #[derive(Serialize, Deserialize, Debug, Clone, PartialEq, Eq)]
@@ -149,415 +154,504 @@ pub enum MessageType {
     Group,
 }
 
-// 发送消息结构体
+/// 发送消息结构体
 #[endpoint("send_msg")]
 #[derive(Serialize, Deserialize, Debug, Clone, PartialEq, Eq)]
 pub struct SendMsg {
-    pub message_type: MessageType,    // 消息类型（private 或 group）
-    pub user_id: Option<i64>,         // 对方 QQ 号（私聊时需要）
-    pub group_id: Option<i64>,        // 群号（群聊时需要）
-    pub message: Vec<MessageSegment>, // 要发送的消息内容
-    pub auto_escape: bool,            // 消息内容是否作为纯文本发送（不解析 CQ 码）
+    /// 消息类型（private 或 group）
+    pub message_type: MessageType,
+    /// 对方 QQ 号（私聊时需要）
+    pub user_id: Option<i64>,
+    /// 群号（群聊时需要）
+    pub group_id: Option<i64>,
+    /// 要发送的消息内容
+    pub message: Vec<MessageSegment>,
+    /// 消息内容是否作为纯文本发送（不解析 CQ 码）
+    pub auto_escape: bool,
 }
 
-// 撤回消息结构体
+/// 撤回消息结构体
 #[endpoint("delete_msg")]
 #[derive(Serialize, Deserialize, Debug, Clone, PartialEq, Eq)]
 pub struct DeleteMsg {
-    pub message_id: i64, // 消息 ID
+    /// 消息 ID
+    pub message_id: i64,
 }
 
-// 获取消息结构体
+/// 获取消息结构体
 #[endpoint("get_msg")]
 #[derive(Serialize, Deserialize, Debug, Clone, PartialEq, Eq)]
 pub struct GetMsg {
-    pub message_id: i64, // 消息 ID
+    /// 消息 ID
+    pub message_id: i64,
 }
 
-// 获取合并转发消息结构体
+/// 获取合并转发消息结构体
 #[endpoint("get_forward_msg")]
 #[derive(Serialize, Deserialize, Debug, Clone, PartialEq, Eq)]
 pub struct GetForwardMsg {
-    pub id: String, // 合并转发 ID
+    /// 合并转发 ID
+    pub id: String,
 }
 
-// 发送好友赞结构体
+/// 发送好友赞结构体
 #[endpoint("send_like")]
 #[derive(Serialize, Deserialize, Debug, Clone, PartialEq, Eq)]
 pub struct SendLike {
-    pub user_id: i64, // 对方 QQ 号
-    pub times: i64,   // 赞的次数，每个好友每天最多 10 次
+    /// 对方 QQ 号
+    pub user_id: i64,
+    /// 赞的次数，每个好友每天最多 10 次
+    pub times: i64,
 }
 
-// 群组踢人结构体
+/// 群组踢人结构体
 #[endpoint("set_group_kick")]
 #[derive(Serialize, Deserialize, Debug, Clone, PartialEq, Eq)]
 pub struct SetGroupKick {
-    pub group_id: i64,            // 群号
-    pub user_id: i64,             // 要踢的 QQ 号
-    pub reject_add_request: bool, // 拒绝此人的加群请求
+    /// 群号
+    pub group_id: i64,
+    /// 要踢的 QQ 号
+    pub user_id: i64,
+    /// 拒绝此人的加群请求
+    pub reject_add_request: bool,
 }
 
-// 群组单人禁言结构体
+/// 群组单人禁言结构体
 #[endpoint("set_group_ban")]
 #[derive(Serialize, Deserialize, Debug, Clone, PartialEq, Eq)]
 pub struct SetGroupBan {
-    pub group_id: i64, // 群号
-    pub user_id: i64,  // 要禁言的 QQ 号
-    pub duration: i64, // 禁言时长，单位秒，0 表示取消禁言
+    /// 群号
+    pub group_id: i64,
+    /// 要禁言的 QQ 号
+    pub user_id: i64,
+    /// 禁言时长，单位秒，0 表示取消禁言
+    pub duration: i64,
 }
 
-// 群组匿名用户禁言结构体
+/// 群组匿名用户禁言结构体
 #[endpoint("set_group_anonymous_ban")]
 #[derive(Serialize, Deserialize, Debug, Clone, PartialEq, Eq)]
 pub struct SetGroupAnonymousBan {
-    pub group_id: i64,                  // 群号
-    pub anonymous: Option<Anonymous>,   // 可选，要禁言的匿名用户对象
-    pub anonymous_flag: Option<String>, // 可选，要禁言的匿名用户的 flag
-    pub duration: i64,                  // 禁言时长，单位秒，无法取消匿名用户禁言
+    /// 群号
+    pub group_id: i64,
+    /// 可选，要禁言的匿名用户对象
+    pub anonymous: Option<Anonymous>,
+    /// 可选，要禁言的匿名用户的 flag
+    pub anonymous_flag: Option<String>,
+    /// 禁言时长，单位秒，无法取消匿名用户禁言
+    pub duration: i64,
 }
 
-// 群组全员禁言结构体
+/// 群组全员禁言结构体
 #[endpoint("set_group_whole_ban")]
 #[derive(Serialize, Deserialize, Debug, Clone, PartialEq, Eq)]
 pub struct SetGroupWholeBan {
-    pub group_id: i64, // 群号
-    pub enable: bool,  // 是否禁言
+    /// 群号
+    pub group_id: i64,
+    /// 是否禁言
+    pub enable: bool,
 }
 
-// 群组设置管理员结构体
+/// 群组设置管理员结构体
 #[endpoint("set_group_admin")]
 #[derive(Serialize, Deserialize, Debug, Clone, PartialEq, Eq)]
 pub struct SetGroupAdmin {
-    pub group_id: i64, // 群号
-    pub user_id: i64,  // 要设置管理员的 QQ 号
-    pub enable: bool,  // true 为设置，false 为取消
+    /// 群号
+    pub group_id: i64,
+    /// 要设置管理员的 QQ 号
+    pub user_id: i64,
+    /// true 为设置，false 为取消
+    pub enable: bool,
 }
 
-// 群组匿名结构体
+/// 群组匿名结构体
 #[endpoint("set_group_anonymous")]
 #[derive(Serialize, Deserialize, Debug, Clone, PartialEq, Eq)]
 pub struct SetGroupAnonymous {
-    pub group_id: i64, // 群号
-    pub enable: bool,  // 是否允许匿名聊天
+    /// 群号
+    pub group_id: i64,
+    /// 是否允许匿名聊天
+    pub enable: bool,
 }
 
-// 设置群名片（群备注）结构体
+/// 设置群名片（群备注）结构体
 #[endpoint("set_group_card")]
 #[derive(Serialize, Deserialize, Debug, Clone, PartialEq, Eq)]
 pub struct SetGroupCard {
-    pub group_id: i64, // 群号
-    pub user_id: i64,  // 要设置的 QQ 号
-    pub card: String,  // 群名片内容，不填或空字符串表示删除群名片
+    /// 群号
+    pub group_id: i64,
+    /// 要设置的 QQ 号
+    pub user_id: i64,
+    /// 群名片内容，不填或空字符串表示删除群名片
+    pub card: String,
 }
 
-// 设置群名结构体
+/// 设置群名结构体
 #[endpoint("set_group_name")]
 #[derive(Serialize, Deserialize, Debug, Clone, PartialEq, Eq)]
 pub struct SetGroupName {
-    pub group_id: i64,      // 群号
-    pub group_name: String, // 新群名
+    /// 群号
+    pub group_id: i64,
+    /// 新群名
+    pub group_name: String,
 }
 
-// 退出群组结构体
+/// 退出群组结构体
 #[endpoint("set_group_leave")]
 #[derive(Serialize, Deserialize, Debug, Clone, PartialEq, Eq)]
 pub struct SetGroupLeave {
-    pub group_id: i64,    // 群号
-    pub is_dismiss: bool, // 是否解散，如果登录号是群主，则仅在此项为 true 时能够解散
+    /// 群号
+    pub group_id: i64,
+    /// 是否解散，如果登录号是群主，则仅在此项为 true 时能够解散
+    pub is_dismiss: bool,
 }
 
-// 设置群组专属头衔结构体
+/// 设置群组专属头衔结构体
 #[endpoint("set_group_special_title")]
 #[derive(Serialize, Deserialize, Debug, Clone, PartialEq, Eq)]
 pub struct SetGroupSpecialTitle {
-    pub group_id: i64,         // 群号
-    pub user_id: i64,          // 要设置的 QQ 号
-    pub special_title: String, // 专属头衔，不填或空字符串表示删除专属头衔
-    pub duration: i64,         // 专属头衔有效期，单位秒，-1 表示永久，此项似乎没有效果，有待测试
+    /// 群号
+    pub group_id: i64,
+    /// 要设置的 QQ 号
+    pub user_id: i64,
+    /// 专属头衔，不填或空字符串表示删除专属头衔
+    pub special_title: String,
+    /// 专属头衔有效期，单位秒，-1 表示永久，此项似乎没有效果，有待测试
+    pub duration: i64,
 }
 
-// 处理加好友请求结构体
+/// 处理加好友请求结构体
 #[endpoint("set_friend_add_request")]
 #[derive(Serialize, Deserialize, Debug, Clone, PartialEq, Eq)]
 pub struct SetFriendAddRequest {
-    pub flag: String,  // 加好友请求的 flag
-    pub approve: bool, // 是否同意请求
+    /// 加好友请求的 flag
+    pub flag: String,
+    /// 是否同意请求
+    pub approve: bool,
+    /// 添加后的好友备注（仅在同意时有效）
     #[serde(skip_serializing_if = "Option::is_none")]
-    pub remark: Option<String>, // 添加后的好友备注（仅在同意时有效）
+    pub remark: Option<String>,
 }
 
-// 处理加群请求／邀请结构体
-#[endpoint("    set_group_add_request")]                                    
+/// 处理加群请求／邀请结构体
+#[endpoint("    set_group_add_request")]
 #[derive(Serialize, Deserialize, Debug, Clone, PartialEq, Eq)]
 pub struct SetGroupAddRequest {
-    pub flag: String,     // 加群请求的 flag
-    pub sub_type: String, // 请求类型（add 或 invite）
-    pub approve: bool,    // 是否同意请求／邀请
+    /// 加群请求的 flag
+    pub flag: String,
+    /// 请求类型（add 或 invite）
+    pub sub_type: String,
+    /// 是否同意请求／邀请
+    pub approve: bool,
+    /// 拒绝理由（仅在拒绝时有效）
     #[serde(skip_serializing_if = "Option::is_none")]
-    pub reason: Option<String>,   // 拒绝理由（仅在拒绝时有效）
+    pub reason: Option<String>,
 }
 
-// 获取登录号信息结构体
+/// 获取登录号信息结构体
 #[endpoint("get_login_info")]
 #[derive(Serialize, Deserialize, Debug, Clone, PartialEq, Eq)]
 pub struct GetLoginInfo {}
 
-// 获取陌生人信息结构体
+/// 获取陌生人信息结构体
 #[endpoint("get_stranger_info")]
 #[derive(Serialize, Deserialize, Debug, Clone, PartialEq, Eq)]
 pub struct GetStrangerInfo {
-    pub user_id: i64,   // QQ 号
-    pub no_cache: bool, // 是否不使用缓存
+    /// QQ 号
+    pub user_id: i64,
+    /// 是否不使用缓存
+    pub no_cache: bool,
 }
 
-// 获取好友列表结构体
+/// 获取好友列表结构体
 #[endpoint("get_friend_list")]
 #[derive(Serialize, Deserialize, Debug, Clone, PartialEq, Eq)]
 pub struct GetFriendList {}
 
-// 获取群信息结构体
+/// 获取群信息结构体
 #[endpoint("get_group_info")]
 #[derive(Serialize, Deserialize, Debug, Clone, PartialEq, Eq)]
 pub struct GetGroupInfo {
-    pub group_id: i64,  // 群号
-    pub no_cache: bool, // 是否不使用缓存
+    /// 群号
+    pub group_id: i64,
+    /// 是否不使用缓存
+    pub no_cache: bool,
 }
 
-// 获取群列表结构体
+/// 获取群列表结构体
 #[endpoint("get_group_list")]
 #[derive(Serialize, Deserialize, Debug, Clone, PartialEq, Eq)]
 pub struct GetGroupList {}
 
-// 获取群成员信息结构体
+/// 获取群成员信息结构体
 #[endpoint("get_group_member_info")]
 #[derive(Serialize, Deserialize, Debug, Clone, PartialEq, Eq)]
 pub struct GetGroupMemberInfo {
-    pub group_id: i64,  // 群号
-    pub user_id: i64,   // QQ 号
-    pub no_cache: bool, // 是否不使用缓存
+    /// 群号
+    pub group_id: i64,
+    /// QQ 号
+    pub user_id: i64,
+    /// 是否不使用缓存
+    pub no_cache: bool,
 }
 
-// 获取群成员列表结构体
+/// 获取群成员列表结构体
 #[endpoint("get_group_member_list")]
 #[derive(Serialize, Deserialize, Debug, Clone, PartialEq, Eq)]
 pub struct GetGroupMemberList {
-    pub group_id: i64, // 群号
+    /// 群号
+    pub group_id: i64,
 }
 
-// 获取群荣誉信息结构体
+/// 获取群荣誉信息结构体
 #[endpoint("get_group_honor_info")]
 #[derive(Serialize, Deserialize, Debug, Clone, PartialEq, Eq)]
 pub struct GetGroupHonorInfo {
-    pub group_id: i64, // 群号
+    /// 群号
+    pub group_id: i64,
+    /// 要获取的群荣誉类型
     #[serde(rename = "type")]
-    pub honor_type: String, // 要获取的群荣誉类型
+    pub honor_type: String,
 }
 
-// 获取 Cookies 结构体
+/// 获取 Cookies 结构体
 #[endpoint("get_cookies")]
 #[derive(Serialize, Deserialize, Debug, Clone, PartialEq, Eq)]
 pub struct GetCookies {
-    pub domain: String, // 需要获取 cookies 的域名
+    /// 需要获取 cookies 的域名
+    pub domain: String,
 }
 
-// 获取 CSRF Token 结构体
+/// 获取 CSRF Token 结构体
 #[endpoint("get_csrf_token")]
 #[derive(Serialize, Deserialize, Debug, Clone, PartialEq, Eq)]
 pub struct GetCsrfToken {}
 
-// 获取 QQ 相关接口凭证结构体
+/// 获取 QQ 相关接口凭证结构体
 #[endpoint("get_credentials")]
 #[derive(Serialize, Deserialize, Debug, Clone, PartialEq, Eq)]
 pub struct GetCredentials {
-    pub domain: String, // 需要获取 cookies 的域名
+    /// 需要获取 cookies 的域名
+    pub domain: String,
 }
 
-// 获取语音结构体
+/// 获取语音结构体
 #[endpoint("get_record")]
 #[derive(Serialize, Deserialize, Debug, Clone, PartialEq, Eq)]
 pub struct GetRecord {
-    pub file: String,       // 收到的语音文件名
-    pub out_format: String, // 要转换到的格式
+    /// 收到的语音文件名
+    pub file: String,
+    /// 要转换到的格式
+    pub out_format: String,
 }
 
-// 获取图片结构体
+/// 获取图片结构体
 #[endpoint("get_image")]
 #[derive(Serialize, Deserialize, Debug, Clone, PartialEq, Eq)]
 pub struct GetImage {
-    pub file: String, // 收到的图片文件名
+    /// 收到的图片文件名
+    pub file: String,
 }
 
-// 检查是否可以发送图片结构体
+/// 检查是否可以发送图片结构体
 #[endpoint("can_send_image")]
 #[derive(Serialize, Deserialize, Debug, Clone, PartialEq, Eq)]
 pub struct CanSendImage {}
 
-// 检查是否可以发送语音结构体
+/// 检查是否可以发送语音结构体
 #[endpoint("can_send_record")]
 #[derive(Serialize, Deserialize, Debug, Clone, PartialEq, Eq)]
 pub struct CanSendRecord {}
 
-// 获取运行状态结构体
+/// 获取运行状态结构体
 #[endpoint("get_status")]
 #[derive(Serialize, Deserialize, Debug, Clone, PartialEq, Eq)]
 pub struct GetStatus {}
 
-// 获取版本信息结构体
+/// 获取版本信息结构体
 #[endpoint("get_version_info")]
 #[derive(Serialize, Deserialize, Debug, Clone, PartialEq, Eq)]
 pub struct GetVersionInfo {}
 
-// 重启 OneBot 实现结构体
+/// 重启 OneBot 实现结构体
 #[endpoint("set_restart")]
 #[derive(Serialize, Deserialize, Debug, Clone, PartialEq, Eq)]
 pub struct SetRestart {
-    pub delay: i64, // 要延迟的毫秒数
+    /// 要延迟的毫秒数
+    pub delay: i64,
 }
 
-// 清理缓存结构体
+/// 清理缓存结构体
 #[endpoint("clean_cache")]
 #[derive(Serialize, Deserialize, Debug, Clone, PartialEq, Eq)]
 pub struct CleanCache {}
 
-// NapCat/llonebot扩展
+// NapCat / llOneBot扩展
 
-// 设置头像✔
+/// 设置头像✔
 #[endpoint("set_qq_avatar")]
 #[derive(Serialize, Deserialize, Debug, Clone, PartialEq, Eq)]
 pub struct SetQQAvatar {
-    pub file: String, // 图片路径/链接/base64
+    /// 图片路径/链接/base64
+    pub file: String,
 }
 
-// 获取群系统通知✔
+/// 获取群系统通知✔
 #[endpoint("get_group_system_msg")]
 #[derive(Serialize, Deserialize, Debug, Clone, PartialEq, Eq)]
 pub struct GetGroupSystemMsg {
-    pub group_id: i64, // 群号
+    /// 群号
+    pub group_id: i64,
 }
 
-// 下载群文件或私聊文件
+/// 下载群文件或私聊文件
 #[endpoint("get_file")]
 #[derive(Serialize, Deserialize, Debug, Clone, PartialEq, Eq)]
 pub struct GetFile {
-    pub file_id: String, // 文件 ID
+    /// 文件 ID
+    pub file_id: String,
 }
 
-// 转发单条消息给好友✔
+/// 转发单条消息给好友✔
 #[endpoint("forward_friend_single_msg")]
 #[derive(Serialize, Deserialize, Debug, Clone, PartialEq, Eq)]
 pub struct ForwardFriendSingleMsg {
-    pub user_id: i64,    // 对方 QQ 号
-    pub message_id: i64, // 消息 ID
+    /// 对方 QQ 号
+    pub user_id: i64,
+    /// 消息 ID
+    pub message_id: i64,
 }
 
-// 转发单条消息给群✔
+/// 转发单条消息给群✔
 #[endpoint("forward_group_single_msg")]
 #[derive(Serialize, Deserialize, Debug, Clone, PartialEq, Eq)]
 pub struct ForwardGroupSingleMsg {
-    pub group_id: i64,   // 群号
-    pub message_id: i64, // 消息 ID
+    /// 群号
+    pub group_id: i64,
+    /// 消息 ID
+    pub message_id: i64,
 }
 
-// 设置表情回应✔
+/// 设置表情回应✔
 #[endpoint("set_msg_emoji_like")]
 #[derive(Serialize, Deserialize, Debug, Clone, PartialEq, Eq)]
 pub struct SetMsgEmojiLike {
-    pub message_id: String, // 消息 ID
-    // emoji_id 参考 https://bot.q.qq.com/wiki/develop/api-v2/openapi/emoji/model.html#EmojiType
-    pub emoji_id: String, // 表情 ID
+    /// 消息 ID
+    pub message_id: String,
+    /// 表情 ID
+    /// 参考 https://bot.q.qq.com/wiki/develop/api-v2/openapi/emoji/model.html#EmojiType
+    pub emoji_id: String,
 }
 
-// 设置私聊消息已读✔
+/// 设置私聊消息已读✔
 #[endpoint("mark_private_msg_as_read")]
 #[derive(Serialize, Deserialize, Debug, Clone, PartialEq, Eq)]
 pub struct MarkPrivateMsgAsRead {
-    pub user_id: i64, // 对方 QQ 号
+    /// 对方 QQ 号
+    pub user_id: i64,
 }
 
-// 设置群消息已读✔
+/// 设置群消息已读✔
 #[endpoint("mark_group_msg_as_read")]
 #[derive(Serialize, Deserialize, Debug, Clone, PartialEq, Eq)]
 pub struct MarkGroupMsgAsRead {
-    pub group_id: i64, // 群号
+    /// 群号
+    pub group_id: i64,
 }
 
-// 获取官方bot qq号范围✔
+/// 获取官方bot qq号范围✔
 #[endpoint("get_robot_uin_range")]
 #[derive(Serialize, Deserialize, Debug, Clone, PartialEq, Eq)]
 pub struct GetRobotUinRange {}
 
-// 设置自身在线状态✔
-// 参考: https://napneko.github.io/zh-CN/develop/status_list
+/// 设置自身在线状态✔
+/// 参考: https://napneko.github.io/zh-CN/develop/status_list
 #[endpoint("set_online_status")]
 #[derive(Serialize, Deserialize, Debug, Clone, PartialEq, Eq)]
 pub struct SetOnlineStatus {
-    pub status: u32, // 在线状态
+    /// 在线状态
+    pub status: u32,
+    // 扩展在线状态
     #[serde(rename = "extStatus")]
-    pub ext_status: u32, // 扩展在线状态
+    pub ext_status: u32,
+    /// 电量状态
     #[serde(rename = "batteryStatus")]
-    pub battery_status: u32, // 电量状态
+    pub battery_status: u32,
 }
 
-// 获取好友分类列表(untested)
+/// 获取好友分类列表(untested)
 #[endpoint("get_friends_with_category")]
 #[derive(Serialize, Deserialize, Debug, Clone, PartialEq, Eq)]
 pub struct GetFriendsWithCategory {}
 
-// 获取群文件数量✔
+/// 获取群文件数量✔
 #[endpoint("get_group_file_count")]
 #[derive(Serialize, Deserialize, Debug, Clone, PartialEq, Eq)]
 pub struct GetGroupFileCount {
-    pub group_id: i64, // 群号
+    // 群号
+    pub group_id: i64,
 }
 
-// 获取群文件列表✔
+/// 获取群文件列表✔
 #[endpoint("get_group_file_list")]
 #[derive(Serialize, Deserialize, Debug, Clone, PartialEq, Eq)]
 pub struct GetGroupFileList {
-    pub group_id: i64,    // 群号
-    pub start_index: i64, // 起始文件序号
-    pub file_count: i64,  // 获取的文件数量
+    /// 群号
+    pub group_id: i64,
+    /// 起始文件序号
+    pub start_index: i64,
+    /// 获取的文件数量
+    pub file_count: i64,
 }
 
-// 创建群文件夹✔
+/// 创建群文件夹✔
 #[endpoint("set_group_file_folder")]
 #[derive(Serialize, Deserialize, Debug, Clone, PartialEq, Eq)]
 pub struct SetGroupFileFolder {
-    pub group_id: i64,       // 群号
-    pub folder_name: String, // 文件夹名称
+    /// 群号
+    pub group_id: i64,
+    /// 文件夹名称
+    pub folder_name: String,
 }
 
-// 删除群文件✔
+/// 删除群文件✔
 #[endpoint("del_group_file")]
 #[derive(Serialize, Deserialize, Debug, Clone, PartialEq, Eq)]
 pub struct DelGroupFile {
-    pub group_id: i64,   // 群号
-    pub file_id: String, // 文件 ID
+    /// 群号
+    pub group_id: i64,
+    /// 文件 ID
+    pub file_id: String,
 }
 
-// 删除群文件夹✔
+/// 删除群文件夹✔
 #[endpoint("del_group_file_folder")]
 #[derive(Serialize, Deserialize, Debug, Clone, PartialEq, Eq)]
 pub struct DelGroupFileFolder {
-    pub group_id: i64,     // 群号
-    pub folder_id: String, // 文件夹 ID
+    /// 群号
+    pub group_id: i64,
+    /// 文件夹 ID
+    pub folder_id: String,
 }
 
-// NapCat gocq拓展
+// NapCat GoCq 拓展
 
-// 合并转发消息给群聊
+/// 合并转发消息给群聊
 #[endpoint("send_group_forward_msg")]
 #[derive(Serialize, Deserialize, Debug, Clone, PartialEq, Eq)]
 pub struct SendGroupForwardMsg {
-    pub group_id: i64,                 // 群号
-    pub messages: Vec<MessageSegment>, // 要发送的消息内容
+    /// 群号
+    pub group_id: i64,
+    /// 要发送的消息内容
+    pub messages: Vec<MessageSegment>,
 }
 
-// 合并转发消息给好友
+/// 合并转发消息给好友
 #[endpoint("send_private_forward_msg")]
 #[derive(Serialize, Deserialize, Debug, Clone, PartialEq, Eq)]
 pub struct SendPrivateForwardMsg {
-    pub user_id: i64,                  // 对方 QQ 号
-    pub messages: Vec<MessageSegment>, // 要发送的消息内容
+    /// 对方 QQ 号
+    pub user_id: i64,
+    /// 要发送的消息内容
+    pub messages: Vec<MessageSegment>,
 }

--- a/onebot_v11/src/api/resp.rs
+++ b/onebot_v11/src/api/resp.rs
@@ -16,7 +16,7 @@ pub struct ApiResp {
 pub struct ApiRespBuilder {
     pub status: String,
     pub retcode: u32,
-    // ApiRespData，但是无法直接序列化，提供一个type_id
+    /// ApiRespData，但是无法直接序列化，提供一个`type_id`
     pub data: Value,
     #[serde(default)]
     pub echo: String,
@@ -60,32 +60,31 @@ pub enum ApiRespData {
     GetStatusResponse(GetStatusResponse),
     GetVersionInfoResponse(GetVersionInfoResponse),
     NoResponse(Option<()>),
-    // NapCat/llonebot扩展
 
-    // 获取群系统通知
+    // NapCat / llOneBot扩展
+    /// 获取群系统通知
     GetGroupSystemMsgResponse(GetGroupSystemMsgResponse),
-    // 下载群文件或私聊文件
+    /// 下载群文件或私聊文件
     GetFileResponse(GetFileResponse),
-    // 获取好友分类列表
+    /// 获取好友分类列表
     GetFriendsWithCategoryResponse(Vec<GetFriendsWithCategoryResponseItem>),
-    // 获取机器人QQ号范围
+    /// 获取机器人QQ号范围
     GetRobotUinRangeResponse(Vec<GetRobotUinRangeResponseItem>),
-    // 获取群文件数量
+    /// 获取群文件数量
     GetGroupFileCountResponse(GetGroupFileCountResponse),
-    // 获取群文件列表
+    /// 获取群文件列表
     GetGroupFileListResponse(GetGroupFileListResponse),
-    // 创建群文件夹
+    /// 创建群文件夹
     SetGroupFileFolderResponse(SetGroupFileFolderResponse),
-    // 删除群文件
+    /// 删除群文件
     DelGroupFileResponse(DelGroupFileResponse),
-    // 删除群文件夹
+    /// 删除群文件夹
     DelGroupFileFolderResponse(CommonClientResponseResult),
 
-    // NapCat Gocq 扩展
-
-    // 向群发送合并转发消息
+    // NapCat GoCq 扩展
+    /// 向群发送合并转发消息
     SendGroupForwardMsgResponse(SendGroupForwardMsgResponse),
-    // 向私聊发送合并转发消息
+    /// 向私聊发送合并转发消息
     SendPrivateForwardMsgResponse(SendPrivateForwardMsgResponse),
 }
 
@@ -119,7 +118,7 @@ impl Serialize for ApiRespData {
             ApiRespData::GetStatusResponse(data) => data.serialize(serializer),
             ApiRespData::GetVersionInfoResponse(data) => data.serialize(serializer),
             ApiRespData::NoResponse(data) => data.serialize(serializer),
-            // NapCat/llonebot扩展
+            // NapCat / llOneBot扩展
             ApiRespData::GetGroupSystemMsgResponse(data) => data.serialize(serializer),
             ApiRespData::GetFileResponse(data) => data.serialize(serializer),
             ApiRespData::GetFriendsWithCategoryResponse(data) => data.serialize(serializer),
@@ -129,7 +128,7 @@ impl Serialize for ApiRespData {
             ApiRespData::DelGroupFileFolderResponse(data) => data.serialize(serializer),
             ApiRespData::GetRobotUinRangeResponse(data) => data.serialize(serializer),
             ApiRespData::GetGroupFileCountResponse(data) => data.serialize(serializer),
-            // NapCat Gocq 扩展
+            // NapCat GoCq 扩展
             ApiRespData::SendGroupForwardMsgResponse(data) => data.serialize(serializer),
             ApiRespData::SendPrivateForwardMsgResponse(data) => data.serialize(serializer),
         }
@@ -460,55 +459,55 @@ pub struct GetVersionInfoResponse {
     pub protocol_version: String,
 }
 
-// NapCat/llonebot扩展
+// NapCat / llOneBot扩展
 
-// 获取群系统通知
+/// 获取群系统通知
 #[derive(Serialize, Deserialize, Debug, Clone, PartialEq, Eq)]
 pub struct GetGroupSystemMsgResponse {
-    // 入群邀请
+    /// 入群邀请
     #[serde(rename = "InvitedRequest")]
     pub invited_requests: Vec<InvitedRequest>,
-    // 被过滤的加群申请
+    /// 被过滤的加群申请
     pub join_requests: Vec<JoinRequest>,
 }
 
 #[derive(Serialize, Deserialize, Debug, Clone, PartialEq, Eq)]
 pub struct InvitedRequest {
-    // 请求id
+    /// 请求id
     pub request_id: String,
-    // 邀请者uin
-    pub invitor_uin: i64,
-    // 邀请者昵称
-    pub invitor_nick: String,
-    // 群号
+    /// 邀请者uin
+    pub inviter_uin: i64,
+    /// 邀请者昵称
+    pub inviter_nick: String,
+    /// 群号
     pub group_id: i64,
-    // 群名称
+    /// 群名称
     pub group_name: String,
-    // 是否处理
+    /// 是否处理
     pub checked: bool,
-    // 0: 未处理 other: 处理者qq
+    /// 0: 未处理 other: 处理者qq
     pub actor: i64,
 }
 
 #[derive(Serialize, Deserialize, Debug, Clone, PartialEq, Eq)]
 pub struct JoinRequest {
-    // 请求id
+    /// 请求id
     pub request_id: String,
-    // 请求者uin
+    /// 请求者uin
     pub requester_uin: i64,
-    // 请求者昵称
+    /// 请求者昵称
     pub requester_nick: String,
-    // 群号
+    /// 群号
     pub group_id: i64,
-    // 群名称
+    /// 群名称
     pub group_name: String,
-    // 是否处理
+    /// 是否处理
     pub checked: bool,
-    // 0: 未处理 other: 处理者qq
+    /// 0: 未处理 other: 处理者qq
     pub actor: i64,
 }
 
-// 下载群文件或私聊文件
+/// 下载群文件或私聊文件
 #[derive(Serialize, Deserialize, Debug, Clone, PartialEq, Eq)]
 pub struct GetFileResponse {
     pub file: String,
@@ -517,7 +516,7 @@ pub struct GetFileResponse {
     pub base64: String,
 }
 
-// 获取好友分类列表
+/// 获取好友分类列表
 #[derive(Serialize, Deserialize, Debug, Clone, PartialEq, Eq)]
 pub struct GetFriendsWithCategoryResponseItem {
     pub user_id: i64,
@@ -528,7 +527,7 @@ pub struct GetFriendsWithCategoryResponseItem {
     pub age: Option<i64>,
     pub qid: Option<String>,
     pub login_days: Option<i64>,
-    pub categroy_name: Option<String>,
+    pub category_name: Option<String>,
     pub category_id: Option<i64>,
 }
 
@@ -542,7 +541,7 @@ pub enum Sex {
     Unknown,
 }
 
-// 获取机器人QQ号范围
+/// 获取机器人QQ号范围
 #[derive(Serialize, Deserialize, Debug, Clone, PartialEq, Eq)]
 pub struct GetRobotUinRangeResponseItem {
     #[serde(rename = "maxUin")]
@@ -551,13 +550,14 @@ pub struct GetRobotUinRangeResponseItem {
     pub min_uin: String,
 }
 
-// 获取群文件数量
+/// 获取群文件数量
 #[derive(Serialize, Deserialize, Debug, Clone, PartialEq, Eq)]
 pub struct GetGroupFileCountResponse {
-    pub count: u64, // 文件数量
+    /// 文件数量
+    pub count: u64,
 }
 
-// 获取群文件列表
+/// 获取群文件列表
 #[derive(Serialize, Deserialize, Debug, Clone, PartialEq, Eq)]
 pub struct GetGroupFileListResponse {
     #[serde(rename = "FileList")]
@@ -648,7 +648,7 @@ pub struct FolderInfo {
     pub used_space: String,
 }
 
-// 创建群文件夹
+/// 创建群文件夹
 #[derive(Serialize, Deserialize, Debug, Clone, PartialEq, Eq)]
 pub struct SetGroupFileFolderResponse {
     #[serde(rename = "groupItem")]
@@ -666,7 +666,7 @@ pub struct CommonClientResponseResult {
     pub ret_msg: String,
 }
 
-// 删除群文件
+/// 删除群文件
 #[derive(Serialize, Deserialize, Debug, Clone, PartialEq, Eq)]
 pub struct DelGroupFileResponse {
     #[serde(rename = "errMsg")]
@@ -685,15 +685,15 @@ pub struct TransGroupFileResult {
     pub success_file_id_list: Vec<String>,
 }
 
-// NapCat Gocq 扩展
+// NapCat / GoCq 扩展
 
-// 向群发送合并转发消息
+/// 向群发送合并转发消息
 #[derive(Serialize, Deserialize, Debug, Clone, PartialEq, Eq)]
 pub struct SendGroupForwardMsgResponse {
     pub message_id: i64,
 }
 
-// 向私聊发送合并转发消息
+/// 向私聊发送合并转发消息
 #[derive(Serialize, Deserialize, Debug, Clone, PartialEq, Eq)]
 pub struct SendPrivateForwardMsgResponse {
     pub message_id: i64,

--- a/onebot_v11/src/connect/http.rs
+++ b/onebot_v11/src/connect/http.rs
@@ -37,7 +37,7 @@ pub struct HttpCallApiResp {
 #[derive(Debug)]
 pub enum HttpCallApiError {
     Unauthorized,
-    InvaildToken,
+    InvalidToken,
     ContentTypeNotSupported,
     InvalidRequestBody,
     ApiNotFound,
@@ -61,7 +61,7 @@ impl From<StatusCode> for HttpCallApiError {
     fn from(value: StatusCode) -> Self {
         match value {
             StatusCode::UNAUTHORIZED => HttpCallApiError::Unauthorized,
-            StatusCode::FORBIDDEN => HttpCallApiError::InvaildToken,
+            StatusCode::FORBIDDEN => HttpCallApiError::InvalidToken,
             StatusCode::NOT_ACCEPTABLE => HttpCallApiError::ContentTypeNotSupported,
             StatusCode::BAD_REQUEST => HttpCallApiError::InvalidRequestBody,
             StatusCode::NOT_FOUND => HttpCallApiError::ApiNotFound,

--- a/onebot_v11/src/connect/mod.rs
+++ b/onebot_v11/src/connect/mod.rs
@@ -2,8 +2,9 @@ use serde::{Deserialize, Serialize};
 use serde_json::Value;
 use tokio::sync::broadcast;
 
+use crate::api::payload::ApiPayload;
 use crate::api::resp::ApiRespBuilder;
-use crate::{api::payload::ApiPayload, traits::EndPoint as _};
+use crate::traits::EndPoint;
 
 pub mod http;
 pub mod ws;

--- a/onebot_v11/src/connect/ws.rs
+++ b/onebot_v11/src/connect/ws.rs
@@ -51,11 +51,11 @@ pub struct WsConnect {
 }
 
 impl WsConnect {
-    pub async fn new(wsconfig: WsConfig) -> Result<Arc<Self>, anyhow::Error> {
-        let (ws_write, ws_read) = Self::connect(&wsconfig).await;
+    pub async fn new(ws_config: WsConfig) -> Result<Arc<Self>, anyhow::Error> {
+        let (ws_write, ws_read) = Self::connect(&ws_config).await;
         let (api_response_sender, _) = broadcast::channel(100);
         let self_ = Arc::new(Self {
-            config: wsconfig.clone(),
+            config: ws_config.clone(),
             ws_read: Mutex::new(ws_read),
             ws_write: Mutex::new(ws_write),
             event_sender: broadcast::channel(100).0,

--- a/onebot_v11/src/connect/ws_reverse.rs
+++ b/onebot_v11/src/connect/ws_reverse.rs
@@ -101,7 +101,7 @@ impl ReverseWsConnect {
                             .get(AUTHORIZATION)
                             .map(|v| v.to_str().unwrap_or("").to_string());
                         tracing::info!(
-                            "Connection accecpting: bot_id: {:?}, type: {:?}, bear_token: {:?}",
+                            "Connection accepting: bot_id: {:?}, type: {:?}, bear_token: {:?}",
                             bot_id,
                             r#type,
                             bear_token

--- a/onebot_v11/src/event/message.rs
+++ b/onebot_v11/src/event/message.rs
@@ -55,100 +55,149 @@ impl<'de> Deserialize<'de> for Message {
     }
 }
 
-// 定义私聊消息结构体
+/// 定义私聊消息结构体
 #[derive(Serialize, Deserialize, Debug, Clone, PartialEq, Eq)]
 pub struct PrivateMessage {
-    pub time: i64,                    // 事件发生的时间戳
-    pub self_id: i64,                 // 收到事件的机器人 QQ 号
-    pub post_type: String,            // 上报类型
-    pub message_type: String,         // 消息类型
-    pub sub_type: String,             // 消息子类型
-    pub message_id: i64,              // 消息 ID
-    pub user_id: i64,                 // 发送者 QQ 号
-    pub message: Vec<MessageSegment>, // 消息内容
-    pub raw_message: String,          // 原始消息内容
-    pub font: i64,                    // 字体
-    pub sender: PrivateMessageSender, // 发送人信息
+    /// 事件发生的时间戳
+    pub time: i64,
+    /// 收到事件的机器人 QQ 号
+    pub self_id: i64,
+    /// 上报类型
+    pub post_type: String,
+    /// 消息类型
+    pub message_type: String,
+    /// 消息子类型
+    pub sub_type: String,
+    /// 消息 ID
+    pub message_id: i64,
+    /// 发送者 QQ 号
+    pub user_id: i64,
+    /// 消息内容
+    pub message: Vec<MessageSegment>,
+    /// 原始消息内容
+    pub raw_message: String,
+    /// 字体
+    pub font: i64,
+    /// 发送人信息
+    pub sender: PrivateMessageSender,
 }
 
-// 发送人信息结构体
+/// 发送人信息结构体
 #[derive(Serialize, Deserialize, Debug, Clone, PartialEq, Eq)]
 pub struct PrivateMessageSender {
+    /// 发送者 QQ 号
     #[serde(skip_serializing_if = "Option::is_none")]
-    pub user_id: Option<i64>, // 发送者 QQ 号
+    pub user_id: Option<i64>,
+    /// 昵称
     #[serde(skip_serializing_if = "Option::is_none")]
-    pub nickname: Option<String>, // 昵称
+    pub nickname: Option<String>,
+    /// 性别
     #[serde(skip_serializing_if = "Option::is_none")]
-    pub sex: Option<String>, // 性别
+    pub sex: Option<String>,
+    /// 年龄
     #[serde(skip_serializing_if = "Option::is_none")]
-    pub age: Option<i32>, // 年龄
+    pub age: Option<i32>,
 }
 
-// 定义群消息结构体
+/// 定义群消息结构体
 #[derive(Serialize, Deserialize, Debug, Clone, PartialEq, Eq)]
 pub struct GroupMessage {
-    pub time: i64,            // 事件发生的时间戳
-    pub self_id: i64,         // 收到事件的机器人 QQ 号
-    pub post_type: String,    // 上报类型
-    pub message_type: String, // 消息类型
-    pub sub_type: String,     // 消息子类型
-    pub message_id: i64,      // 消息 ID
-    pub group_id: i64,        // 群号
-    pub user_id: i64,         // 发送者 QQ 号
+    /// 事件发生的时间戳
+    pub time: i64,
+    /// 收到事件的机器人 QQ 号
+    pub self_id: i64,
+    /// 上报类型
+    pub post_type: String,
+    /// 消息类型
+    pub message_type: String,
+    /// 消息子类型
+    pub sub_type: String,
+    /// 消息 ID
+    pub message_id: i64,
+    /// 群号
+    pub group_id: i64,
+    /// 发送者 QQ 号
+    pub user_id: i64,
+    /// 匿名信息，如果不是匿名消息则为 null
     #[serde(skip_serializing_if = "Option::is_none")]
-    pub anonymous: Option<Anonymous>, // 匿名信息，如果不是匿名消息则为 null
-    pub message: Vec<MessageSegment>, // 消息内容
-    pub raw_message: String,  // 原始消息内容
-    pub font: i64,            // 字体
-    pub sender: GroupMessageSender, // 发送人信息
+    pub anonymous: Option<Anonymous>,
+    /// 消息内容
+    pub message: Vec<MessageSegment>,
+    /// 原始消息内容
+    pub raw_message: String,
+    /// 字体
+    pub font: i64,
+    /// 发送人信息
+    pub sender: GroupMessageSender,
 }
 
 #[derive(Serialize, Deserialize, Debug, Clone, PartialEq, Eq)]
 pub struct GroupMessageSender {
+    /// 发送者 QQ 号
     #[serde(skip_serializing_if = "Option::is_none")]
-    pub user_id: Option<i64>, // 发送者 QQ 号
+    pub user_id: Option<i64>,
+    /// 昵称
     #[serde(skip_serializing_if = "Option::is_none")]
-    pub nickname: Option<String>, // 昵称
+    pub nickname: Option<String>,
+    /// 群名片／备注
     #[serde(skip_serializing_if = "Option::is_none")]
-    pub card: Option<String>, // 群名片／备注
+    pub card: Option<String>,
+    /// 性别
     #[serde(skip_serializing_if = "Option::is_none")]
-    pub sex: Option<String>, // 性别
+    pub sex: Option<String>,
+    /// 年龄
     #[serde(skip_serializing_if = "Option::is_none")]
-    pub age: Option<i32>, // 年龄
+    pub age: Option<i32>,
+    /// 地区
     #[serde(skip_serializing_if = "Option::is_none")]
-    pub area: Option<String>, // 地区
+    pub area: Option<String>,
+    /// 成员等级
     #[serde(skip_serializing_if = "Option::is_none")]
-    pub level: Option<String>, // 成员等级
+    pub level: Option<String>,
+    /// 角色
     #[serde(skip_serializing_if = "Option::is_none")]
-    pub role: Option<String>, // 角色
+    pub role: Option<String>,
+    /// 专属头衔
     #[serde(skip_serializing_if = "Option::is_none")]
-    pub title: Option<String>, // 专属头衔
+    pub title: Option<String>,
 }
 
-// 匿名消息结构体
+/// 匿名消息结构体
 #[derive(Serialize, Deserialize, Debug, Clone, PartialEq, Eq)]
 pub struct Anonymous {
-    pub id: i64,      // 匿名用户 ID
-    pub name: String, // 匿名用户名称
-    pub flag: String, // 匿名用户 flag，在调用禁言 API 时需要传入
+    /// 匿名用户 ID
+    pub id: i64,
+    /// 匿名用户名称
+    pub name: String,
+    /// 匿名用户 flag，在调用禁言 API 时需要传入
+    pub flag: String,
 }
 
 // 以下暂且不用
 
-// // 私聊消息的快速操作结构体
+/// 私聊消息的快速操作结构体
 #[derive(Serialize, Deserialize, Debug, Clone, PartialEq, Eq)]
 pub struct PrivateMessageQuickOperation {
-    pub reply: Vec<MessageSegment>, // 要回复的内容
-    pub auto_escape: bool,          // 消息内容是否作为纯文本发送
+    /// 要回复的内容
+    pub reply: Vec<MessageSegment>,
+    /// 消息内容是否作为纯文本发送
+    pub auto_escape: bool,
 }
-// 群消息的快速操作结构体
+/// 群消息的快速操作结构体
 #[derive(Serialize, Deserialize, Debug, Clone, PartialEq, Eq)]
 pub struct GroupMessageQuickOperation {
-    pub reply: Vec<MessageSegment>, // 要回复的内容
-    pub auto_escape: bool,          // 消息内容是否作为纯文本发送
-    pub at_sender: bool,            // 是否要在回复开头 at 发送者
-    pub delete: bool,               // 撤回该条消息
-    pub kick: bool,                 // 把发送者踢出群组
-    pub ban: bool,                  // 把发送者禁言
-    pub ban_duration: i32,          // 禁言时长
+    /// 要回复的内容
+    pub reply: Vec<MessageSegment>,
+    /// 消息内容是否作为纯文本发送
+    pub auto_escape: bool,
+    /// 是否要在回复开头 at 发送者
+    pub at_sender: bool,
+    /// 撤回该条消息
+    pub delete: bool,
+    /// 把发送者踢出群组
+    pub kick: bool,
+    /// 把发送者禁言
+    pub ban: bool,
+    /// 禁言时长
+    pub ban_duration: i32,
 }

--- a/onebot_v11/src/event/notice.rs
+++ b/onebot_v11/src/event/notice.rs
@@ -1,36 +1,37 @@
 use serde::de::Error;
 use serde::{Deserialize, Serialize};
+
 #[derive(Debug, Clone, PartialEq, Eq)]
 pub enum Notice {
-    // 群文件上传事件
+    /// 群文件上传事件
     GroupFileUpload(GroupFileUploadEvent),
-    // 群管理员变动事件
+    /// 群管理员变动事件
     GroupAdminChange(GroupAdminChangeEvent),
-    // 群成员减少事件
+    /// 群成员减少事件
     GroupMemberDecrease(GroupMemberDecreaseEvent),
-    // 群成员增加事件
+    /// 群成员增加事件
     GroupMemberIncrease(GroupMemberIncreaseEvent),
-    // 群禁言事件
+    /// 群禁言事件
     GroupBan(GroupBanEvent),
-    // 好友添加事件
+    /// 好友添加事件
     FriendAdd(FriendAddEvent),
-    // 群消息撤回事件
+    /// 群消息撤回事件
     GroupMessageRecall(GroupMessageRecallEvent),
-    // 好友消息撤回事件
+    /// 好友消息撤回事件
     FriendMessageRecall(FriendMessageRecallEvent),
-    // 群内戳一戳事件
+    /// 群内戳一戳事件
     GroupPoke(GroupPokeEvent),
-    // 群红包运气王事件
+    /// 群红包运气王事件
     GroupLuckyKing(GroupLuckyKingEvent),
-    // 群成员荣誉变更事件
+    /// 群成员荣誉变更事件
     GroupMemberHonorChange(GroupMemberHonorChangeEvent),
 
-    // 仅Napcat/llonebot支持的事件
-    // 私聊输入状态事件
+    // 仅NapCat / llOneBot 支持的事件
+    /// 私聊输入状态事件
     FriendInputStatusChange(FriendInputStatusChangeEvent),
-    // 群精华消息事件
+    /// 群精华消息事件
     GroupEssenceMessageChange(GroupEssenceMessageChangeEvent),
-    // 群名片变更事件
+    /// 群名片变更事件
     GroupCardChange(GroupCardChangeEvent),
 }
 impl<'de> Deserialize<'de> for Notice {
@@ -64,7 +65,7 @@ impl<'de> Deserialize<'de> for Notice {
             Some("friend_recall") => serde_json::from_value(value)
                 .map(Notice::FriendMessageRecall)
                 .map_err(D::Error::custom),
-            // 仅Napcat/llonebot支持的事件
+            // 仅NapCat / llOneBot 支持的事件
             Some("essence") => serde_json::from_value(value)
                 .map(Notice::GroupEssenceMessageChange)
                 .map_err(D::Error::custom),
@@ -82,7 +83,7 @@ impl<'de> Deserialize<'de> for Notice {
                 Some("honor") => serde_json::from_value(value)
                     .map(Notice::GroupMemberHonorChange)
                     .map_err(D::Error::custom),
-                // 仅Napcat/llonebot支持的事件
+                // 仅NapCat / llOneBot 支持的事件
                 Some("input_status") => serde_json::from_value(value)
                     .map(Notice::FriendInputStatusChange)
                     .map_err(D::Error::custom),
@@ -121,7 +122,7 @@ impl<'de> Deserialize<'de> for Notice {
             Some("friend_recall") => serde_json::from_value(value)
                 .map(Notice::FriendMessageRecall)
                 .map_err(D::Error::custom)?,
-            // 仅Napcat/llonebot支持的事件
+            // 仅 NapCat / llOneBot 支持的事件
             Some("essence") => serde_json::from_value(value)
                 .map(Notice::GroupEssenceMessageChange)
                 .map_err(D::Error::custom)?,
@@ -139,7 +140,7 @@ impl<'de> Deserialize<'de> for Notice {
                 Some("honor") => serde_json::from_value(value)
                     .map(Notice::GroupMemberHonorChange)
                     .map_err(D::Error::custom)?,
-                // 仅Napcat/llonebot支持的事件
+                // 仅 NapCat / llOneBot 支持的事件
                 Some("input_status") => serde_json::from_value(value)
                     .map(Notice::FriendInputStatusChange)
                     .map_err(D::Error::custom)?,
@@ -174,179 +175,273 @@ impl Serialize for Notice {
         }
     }
 }
-
-// 群文件上传事件
+/// 群文件上传事件
 #[derive(Serialize, Deserialize, Debug, Clone, PartialEq, Eq)]
 pub struct GroupFileUploadEvent {
-    pub time: i64,           // 事件发生的时间戳
-    pub self_id: i64,        // 收到事件的机器人 QQ 号
-    pub post_type: String,   // 上报类型
-    pub notice_type: String, // 通知类型
-    pub group_id: i64,       // 群号
-    pub user_id: i64,        // 发送者 QQ 号
-    pub file: GroupFile,     // 文件信息
+    /// 事件发生的时间戳
+    pub time: i64,
+    /// 收到事件的机器人 QQ 号
+    pub self_id: i64,
+    /// 上报类型
+    pub post_type: String,
+    /// 通知类型
+    pub notice_type: String,
+    /// 群号
+    pub group_id: i64,
+    /// 发送者 QQ 号
+    pub user_id: i64,
+    /// 文件信息
+    pub file: GroupFile,
 }
 
-// 群文件信息
+/// 群文件信息
 #[derive(Serialize, Deserialize, Debug, Clone, PartialEq, Eq)]
 pub struct GroupFile {
-    pub id: String,   // 文件 ID
-    pub name: String, // 文件名
-    pub size: i64,    // 文件大小（字节数）
-    pub busid: i64,   // busid（目前不清楚有什么作用）
+    /// 文件 ID
+    pub id: String,
+    /// 文件名
+    pub name: String,
+    /// 文件大小（字节数）
+    pub size: i64,
+    /// busid（目前不清楚有什么作用）
+    pub busid: i64,
 }
 
-// 群管理员变动事件
+/// 群管理员变动事件
 #[derive(Serialize, Deserialize, Debug, Clone, PartialEq, Eq)]
 pub struct GroupAdminChangeEvent {
-    pub time: i64,           // 事件发生的时间戳
-    pub self_id: i64,        // 收到事件的机器人 QQ 号
-    pub post_type: String,   // 上报类型
-    pub notice_type: String, // 通知类型
-    pub sub_type: String,    // 事件子类型，分别表示设置和取消管理员
-    pub group_id: i64,       // 群号
-    pub user_id: i64,        // 管理员 QQ 号
+    /// 事件发生的时间戳
+    pub time: i64,
+    /// 收到事件的机器人 QQ 号
+    pub self_id: i64,
+    /// 上报类型
+    pub post_type: String,
+    /// 通知类型
+    pub notice_type: String,
+    /// 事件子类型，分别表示设置和取消管理员
+    pub sub_type: String,
+    /// 群号
+    pub group_id: i64,
+    /// 管理员 QQ 号
+    pub user_id: i64,
 }
 
-// 群成员减少事件
+/// 群成员减少事件
 #[derive(Serialize, Deserialize, Debug, Clone, PartialEq, Eq)]
 pub struct GroupMemberDecreaseEvent {
-    pub time: i64,           // 事件发生的时间戳
-    pub self_id: i64,        // 收到事件的机器人 QQ 号
-    pub post_type: String,   // 上报类型
-    pub notice_type: String, // 通知类型
-    pub sub_type: String,    // 事件子类型，分别表示主动退群、成员被踢、登录号被踢
-    pub group_id: i64,       // 群号
-    pub operator_id: i64,    // 操作者 QQ 号（如果是主动退群，则和 `user_id` 相同）
-    pub user_id: i64,        // 离开者 QQ 号
+    /// 事件发生的时间戳
+    pub time: i64,
+    /// 收到事件的机器人 QQ 号
+    pub self_id: i64,
+    /// 上报类型
+    pub post_type: String,
+    /// 通知类型
+    pub notice_type: String,
+    /// 事件子类型，分别表示主动退群、成员被踢、登录号被踢
+    pub sub_type: String,
+    /// 群号
+    pub group_id: i64,
+    /// 操作者 QQ 号（如果是主动退群，则和 `user_id` 相同）
+    pub operator_id: i64,
+    /// 离开者 QQ 号
+    pub user_id: i64,
 }
 
-// 群成员增加事件
+/// 群成员增加事件
 #[derive(Serialize, Deserialize, Debug, Clone, PartialEq, Eq)]
 pub struct GroupMemberIncreaseEvent {
-    pub time: i64,           // 事件发生的时间戳
-    pub self_id: i64,        // 收到事件的机器人 QQ 号
-    pub post_type: String,   // 上报类型
-    pub notice_type: String, // 通知类型
-    pub sub_type: String,    // 事件子类型，分别表示管理员已同意入群、管理员邀请入群
-    pub group_id: i64,       // 群号
-    pub operator_id: i64,    // 操作者 QQ 号
-    pub user_id: i64,        // 加入者 QQ 号
+    /// 事件发生的时间戳
+    pub time: i64,
+    /// 收到事件的机器人 QQ 号
+    pub self_id: i64,
+    /// 上报类型
+    pub post_type: String,
+    /// 通知类型
+    pub notice_type: String,
+    /// 事件子类型，分别表示管理员已同意入群、管理员邀请入群
+    pub sub_type: String,
+    /// 群号
+    pub group_id: i64,
+    /// 操作者 QQ 号
+    pub operator_id: i64,
+    /// 加入者 QQ 号
+    pub user_id: i64,
 }
 
-// 群禁言事件
+/// 群禁言事件
 #[derive(Serialize, Deserialize, Debug, Clone, PartialEq, Eq)]
 pub struct GroupBanEvent {
-    pub time: i64,           // 事件发生的时间戳
-    pub self_id: i64,        // 收到事件的机器人 QQ 号
-    pub post_type: String,   // 上报类型
-    pub notice_type: String, // 通知类型
-    pub sub_type: String,    // 事件子类型，分别表示禁言、解除禁言
-    pub group_id: i64,       // 群号
-    pub operator_id: i64,    // 操作者 QQ 号
-    pub user_id: i64,        // 被禁言 QQ 号
-    pub duration: u64,       // 禁言时长，单位秒
+    /// 事件发生的时间戳
+    pub time: i64,
+    /// 收到事件的机器人 QQ 号
+    pub self_id: i64,
+    /// 上报类型
+    pub post_type: String,
+    /// 通知类型
+    pub notice_type: String,
+    /// 事件子类型，分别表示禁言、解除禁言
+    pub sub_type: String,
+    /// 群号
+    pub group_id: i64,
+    /// 操作者 QQ 号
+    pub operator_id: i64,
+    /// 被禁言 QQ 号
+    pub user_id: i64,
+    /// 禁言时长，单位秒
+    pub duration: u64,
 }
 
-// 好友添加事件
+/// 好友添加事件
 #[derive(Serialize, Deserialize, Debug, Clone, PartialEq, Eq)]
 pub struct FriendAddEvent {
-    pub time: i64,           // 事件发生的时间戳
-    pub self_id: i64,        // 收到事件的机器人 QQ 号
-    pub post_type: String,   // 上报类型
-    pub notice_type: String, // 通知类型
-    pub user_id: i64,        // 新添加好友 QQ 号
+    /// 事件发生的时间戳
+    pub time: i64,
+    /// 收到事件的机器人 QQ 号
+    pub self_id: i64,
+    /// 上报类型
+    pub post_type: String,
+    /// 通知类型
+    pub notice_type: String,
+    /// 新添加好友 QQ 号
+    pub user_id: i64,
 }
 
-// 群消息撤回事件
+/// 群消息撤回事件
 #[derive(Serialize, Deserialize, Debug, Clone, PartialEq, Eq)]
 pub struct GroupMessageRecallEvent {
-    pub time: i64,           // 事件发生的时间戳
-    pub self_id: i64,        // 收到事件的机器人 QQ 号
-    pub post_type: String,   // 上报类型
-    pub notice_type: String, // 通知类型
-    pub group_id: i64,       // 群号
-    pub user_id: i64,        // 消息发送者 QQ 号
-    pub operator_id: i64,    // 操作者 QQ 号
-    pub message_id: i64,     // 被撤回的消息 ID
+    /// 事件发生的时间戳
+    pub time: i64,
+    /// 收到事件的机器人 QQ 号
+    pub self_id: i64,
+    /// 上报类型
+    pub post_type: String,
+    /// 通知类型
+    pub notice_type: String,
+    /// 群号
+    pub group_id: i64,
+    /// 消息发送者 QQ 号
+    pub user_id: i64,
+    /// 操作者 QQ 号
+    pub operator_id: i64,
+    /// 被撤回的消息 ID
+    pub message_id: i64,
 }
 
-// 好友消息撤回事件
+/// 好友消息撤回事件
 #[derive(Serialize, Deserialize, Debug, Clone, PartialEq, Eq)]
 pub struct FriendMessageRecallEvent {
-    pub time: i64,           // 事件发生的时间戳
-    pub self_id: i64,        // 收到事件的机器人 QQ 号
-    pub post_type: String,   // 上报类型
-    pub notice_type: String, // 通知类型
-    pub user_id: i64,        // 好友 QQ 号
-    pub message_id: i64,     // 被撤回的消息 ID
+    /// 事件发生的时间戳
+    pub time: i64,
+    /// 收到事件的机器人 QQ 号
+    pub self_id: i64,
+    /// 上报类型
+    pub post_type: String,
+    /// 通知类型
+    pub notice_type: String,
+    /// 好友 QQ 号
+    pub user_id: i64,
+    /// 被撤回的消息 ID
+    pub message_id: i64,
 }
 
-// 群内戳一戳事件
+/// 群内戳一戳事件
 #[derive(Serialize, Deserialize, Debug, Clone, PartialEq, Eq)]
 pub struct GroupPokeEvent {
-    pub time: i64,           // 事件发生的时间戳
-    pub self_id: i64,        // 收到事件的机器人 QQ 号
-    pub post_type: String,   // 上报类型
-    pub notice_type: String, // 通知类型
-    pub sub_type: String,    // 子类型
-    pub group_id: i64,       // 群号
-    pub user_id: i64,        // 发送者 QQ 号
-    pub target_id: i64,      // 被戳者 QQ 号
+    /// 事件发生的时间戳
+    pub time: i64,
+    /// 收到事件的机器人 QQ 号
+    pub self_id: i64,
+    /// 上报类型
+    pub post_type: String,
+    /// 通知类型
+    pub notice_type: String,
+    /// 子类型
+    pub sub_type: String,
+    /// 群号
+    pub group_id: i64,
+    /// 发送者 QQ 号
+    pub user_id: i64,
+    /// 被戳者 QQ 号
+    pub target_id: i64,
 }
 
-// 群红包运气王事件
+/// 群红包运气王事件
 #[derive(Serialize, Deserialize, Debug, Clone, PartialEq, Eq)]
 pub struct GroupLuckyKingEvent {
-    pub time: i64,           // 事件发生的时间戳
-    pub self_id: i64,        // 收到事件的机器人 QQ 号
-    pub post_type: String,   // 上报类型
-    pub notice_type: String, // 通知类型
-    pub sub_type: String,    // 子类型
-    pub group_id: i64,       // 群号
-    pub user_id: i64,        // 红包发送者 QQ 号
-    pub target_id: i64,      // 运气王 QQ 号
+    /// 事件发生的时间戳
+    pub time: i64,
+    /// 收到事件的机器人 QQ 号
+    pub self_id: i64,
+    /// 上报类型
+    pub post_type: String,
+    /// 通知类型
+    pub notice_type: String,
+    /// 子类型
+    pub sub_type: String,
+    /// 群号
+    pub group_id: i64,
+    /// 红包发送者 QQ 号
+    pub user_id: i64,
+    /// 运气王 QQ 号
+    pub target_id: i64,
 }
 
-// 群成员荣誉变更事件
+/// 群成员荣誉变更事件
 #[derive(Serialize, Deserialize, Debug, Clone, PartialEq, Eq)]
 pub struct GroupMemberHonorChangeEvent {
-    pub time: i64,           // 事件发生的时间戳
-    pub self_id: i64,        // 收到事件的机器人 QQ 号
-    pub post_type: String,   // 上报类型
-    pub notice_type: String, // 通知类型
-    pub sub_type: String,    // 子类型
-    pub group_id: i64,       // 群号
-    pub honor_type: String,  // 荣誉类型，分别表示龙王、群聊之火、快乐源泉
-    pub user_id: i64,        // 成员 QQ 号
+    /// 事件发生的时间戳
+    pub time: i64,
+    /// 收到事件的机器人 QQ 号
+    pub self_id: i64,
+    /// 上报类型
+    pub post_type: String,
+    /// 通知类型
+    pub notice_type: String,
+    /// 子类型
+    pub sub_type: String,
+    /// 群号
+    pub group_id: i64,
+    /// 荣誉类型，分别表示龙王、群聊之火、快乐源泉
+    pub honor_type: String,
+    /// 成员 QQ 号
+    pub user_id: i64,
 }
 
-// 仅Napcat/llonebot支持的事件
-// 私聊输入状态事件
+// 仅 NapCat / llOneBot 支持的事件
+/// 私聊输入状态事件
 #[derive(Serialize, Deserialize, Debug, Clone, PartialEq, Eq)]
 pub struct FriendInputStatusChangeEvent {
-    pub time: i64,           // 事件发生的时间戳
-    pub self_id: i64,        // 收到事件的机器人 QQ 号
-    pub post_type: String,   // 上报类型
-    pub notice_type: String, // 通知类型
-    pub sub_type: String,    // 子类型
-    pub status_text: String, // 输入状态文本
-    pub event_type: u8,      // 事件类型
-    pub user_id: i64,        // 好友 QQ 号
+    /// 事件发生的时间戳
+    pub time: i64,
+    /// 收到事件的机器人 QQ 号
+    pub self_id: i64,
+    /// 上报类型
+    pub post_type: String,
+    /// 通知类型
+    pub notice_type: String,
+    /// 子类型
+    pub sub_type: String,
+    /// 输入状态文本
+    pub status_text: String,
+    /// 事件类型
+    pub event_type: u8,
+    /// 好友 QQ 号
+    pub user_id: i64,
 }
 
-// 输入状态
+/// 输入状态
 #[derive(Debug, Clone, PartialEq, Eq)]
 pub enum InputStatus {
-    // 开始输入
+    /// 开始输入
     Start,
-    // 继续输入
+    /// 继续输入
     Typing,
-    // 清空输入
+    /// 清空输入
     Cleared,
 }
 
 impl FriendInputStatusChangeEvent {
+    /// 转换为输入状态
     pub fn to_status(&self) -> InputStatus {
         if !self.status_text.is_empty() {
             if self.event_type == 1 {
@@ -361,40 +456,57 @@ impl FriendInputStatusChangeEvent {
 }
 
 #[derive(Serialize, Deserialize, Debug, Clone, PartialEq, Eq)]
-pub enum EssenseMessageChangeType {
-    // 精华消息添加
+pub enum EssenceMessageChangeType {
+    /// 精华消息添加
     #[serde(rename = "add")]
     Add,
-    // 精华消息删除
+    /// 精华消息删除
     #[serde(rename = "delete")]
     Delete,
 }
 
-// 仅Napcat/llonebot支持的事件
+// 仅NapCat / llOneBot 支持的事件
 
-// 精华消息事件
+/// 精华消息事件
 #[derive(Serialize, Deserialize, Debug, Clone, PartialEq, Eq)]
-pub struct      GroupEssenceMessageChangeEvent {
-    pub time: i64,                          // 事件发生的时间戳
-    pub self_id: i64,                       // 收到事件的机器人 QQ 号
-    pub post_type: String,                  // 上报类型
-    pub group_id: i64,                      // 群号
-    pub user_id: i64,                       // 操作者 QQ 号
-    pub notice_type: String,                // 通知类型
-    pub message_id: i64,                    // 消息 ID
-    pub sender_id: i64,                     // 发送者 QQ 号
-    pub sub_type: EssenseMessageChangeType, // 子类型
+pub struct GroupEssenceMessageChangeEvent {
+    /// 事件发生的时间戳
+    pub time: i64,
+    /// 收到事件的机器人 QQ 号
+    pub self_id: i64,
+    /// 上报类型
+    pub post_type: String,
+    /// 群号
+    pub group_id: i64,
+    /// 操作者 QQ 号
+    pub user_id: i64,
+    /// 通知类型
+    pub notice_type: String,
+    /// 消息 ID
+    pub message_id: i64,
+    /// 发送者 QQ 号
+    pub sender_id: i64,
+    /// 子类型
+    pub sub_type: EssenceMessageChangeType,
 }
 
-// 群名片变更事件
+/// 群名片变更事件
 #[derive(Serialize, Deserialize, Debug, Clone, PartialEq, Eq)]
 pub struct GroupCardChangeEvent {
-    pub time: i64,           // 事件发生的时间戳
-    pub self_id: i64,        // 收到事件的机器人 QQ 号
-    pub post_type: String,   // 上报类型
-    pub notice_type: String, // 通知类型
-    pub group_id: i64,       // 群号
-    pub user_id: i64,        // 用户 QQ 号
-    pub card_new: String,    // 新名片
-    pub card_old: String,    // 旧名片
+    /// 事件发生的时间戳
+    pub time: i64,
+    /// 收到事件的机器人 QQ 号
+    pub self_id: i64,
+    /// 上报类型
+    pub post_type: String,
+    /// 通知类型
+    pub notice_type: String,
+    /// 群号
+    pub group_id: i64,
+    /// 用户 QQ 号
+    pub user_id: i64,
+    /// 新名片
+    pub card_new: String,
+    /// 旧名片
+    pub card_old: String,
 }

--- a/onebot_v11/src/message/segment.rs
+++ b/onebot_v11/src/message/segment.rs
@@ -4,88 +4,88 @@ use serde_json::{json, Value};
 #[derive(Serialize, Deserialize, Debug, Clone, PartialEq, Eq)]
 #[serde(tag = "type")]
 pub enum MessageSegment {
-    // 文本
+    /// 文本
     #[serde(rename = "text")]
     Text { data: TextData },
-    // qq表情
+    /// qq表情
     #[serde(rename = "face")]
     Face { data: FaceData },
-    // qq商店表情
+    /// qq商店表情
     #[serde(rename = "mface")]
-    Mface { data: MfaceData },
-    // @
+    MFace { data: MFaceData },
+    /// @
     #[serde(rename = "at")]
     At { data: AtData },
-    // 图片
+    /// 图片
     #[serde(rename = "image")]
     Image { data: ImageData },
-    // 语音
+    /// 语音
     #[serde(rename = "record")]
     Record { data: RecordData },
-    // 视频
+    /// 视频
     #[serde(rename = "video")]
     Video { data: VideoData },
-    // 文件
+    /// 文件
     #[serde(rename = "file")]
     File { data: File },
-    // 猜拳魔法表情
+    /// 猜拳魔法表情
     #[serde(rename = "rps")]
     Rps {
-        // 发: {}
+        /// 发: {}
         #[serde(default = "default_value")]
         data: Value,
     },
-    // 掷骰子魔法表情
+    /// 掷骰子魔法表情
     #[serde(rename = "dice")]
     Dice {
-        // 发: {}
+        /// 发: {}
         #[serde(default = "default_value")]
         data: Value,
     },
-    // 窗口抖动（戳一戳）
+    /// 窗口抖动（戳一戳）
     #[serde(rename = "shake")]
     Shake {
-        // 发: {}
+        /// 发: {}
         #[serde(default = "default_value")]
         data: Value,
     },
-    // 戳一戳
+    /// 戳一戳
     #[serde(rename = "poke")]
     Poke { data: PokeData },
-    // 匿名发消息
+    /// 匿名发消息
     #[serde(rename = "anonymous")]
     Anonymous { data: AnonymousData },
-    // 分享
+    /// 分享
     #[serde(rename = "share")]
     Share { data: ShareData },
-    // 推荐好友或群
+    /// 推荐好友或群
     #[serde(rename = "contact")]
     Contact { data: ContactData },
-    // 位置
+    /// 位置
     #[serde(rename = "location")]
     Location { data: LocationData },
-    // 音乐分享
+    /// 音乐分享
     #[serde(rename = "music")]
     Music { data: MusicData },
-    // 自定义音乐分享
+    /// 自定义音乐分享
     #[serde(rename = "custom_music")]
     CustomMusic { data: CustomMusicData },
-    // 回复
+    /// 回复
     #[serde(rename = "reply")]
     Reply { data: ReplyData },
-    // 合并转发
+    /// 合并转发
     #[serde(rename = "forward")]
     Forward { data: ForwardData },
-    // 合并转发节点
+    /// 合并转发节点
     #[serde(rename = "node")]
     Node { data: NodeData },
-    // 合并转发自定义节点
+    /// 合并转发自定义节点
     #[serde(rename = "node")]
     CustomNode { data: CustomNodeData },
-    // xml消息
+    /// xml消息
     #[serde(rename = "xml")]
     Xml { data: XmlData },
-    // json消息
+    /// json消息
     #[serde(rename = "json")]
     Json { data: JsonData },
 }
@@ -95,18 +95,20 @@ fn default_value() -> Value {
 }
 
 impl MessageSegment {
-    // 文本信息
+    /// 文本信息
     pub fn text(text: impl Into<String>) -> Self {
         MessageSegment::Text {
             data: TextData { text: text.into() },
         }
     }
-    // qq表情
+
+    /// qq表情
     pub fn face(id: impl Into<String>) -> Self {
         MessageSegment::Face {
             data: FaceData { id: id.into() },
         }
     }
+
     pub fn mface(
         summary: impl Into<String>,
         url: impl Into<String>,
@@ -114,8 +116,8 @@ impl MessageSegment {
         emoji_package_id: impl Into<String>,
         key: impl Into<String>,
     ) -> Self {
-        MessageSegment::Mface {
-            data: MfaceData {
+        MessageSegment::MFace {
+            data: MFaceData {
                 summary: summary.into(),
                 url: url.into(),
                 emoji_id: emoji_id.into(),
@@ -124,7 +126,8 @@ impl MessageSegment {
             },
         }
     }
-    // @
+
+    /// @
     pub fn at(qq: impl Into<String>) -> Self {
         MessageSegment::At {
             data: AtData { qq: qq.into() },
@@ -300,7 +303,7 @@ impl MessageSegment {
         }
     }
 
-    // llonebot/NapCat 无法自定义昵称和uin, Lagrange可以但是不能发送大于1mb的video
+    /// llonebot/NapCat 无法自定义昵称和uin, Lagrange可以但是不能发送大于1mb的video
     pub fn custom_node(uin: i64, name: impl Into<String>, content: Vec<MessageSegment>) -> Self {
         MessageSegment::CustomNode {
             data: CustomNodeData {
@@ -362,153 +365,153 @@ impl MessageSegment {
     }
 }
 
-// 以下未标志收发的，均为收发均可
+/// 以下未标志收发的，均为收发均可
 
 #[derive(Serialize, Deserialize, Debug, Clone, PartialEq, Eq)]
 pub struct TextData {
-    // 文本内容
+    /// 文本内容
     pub text: String,
 }
 
 #[derive(Serialize, Deserialize, Debug, Clone, PartialEq, Eq)]
 pub struct FaceData {
-    // QQ 表情的 ID
+    /// QQ 表情的 ID
     pub id: String,
 }
 
 #[derive(Serialize, Deserialize, Debug, Clone, PartialEq, Eq)]
 pub struct ImageData {
-    // 图片文件名, 使用收到的图片文件名直接发送
-    // 绝对路径，例如 file:///C:\\Users\Richard\Pictures\1.png，格式使用 file URI
-    // 网络 URL，例如 http://i1.piimg.com/567571/fdd6e7b6d93f1ef0.jpg
-    // Base64 编码，例如 base64://iVBORw0KGgoAAAANSUhEUgAAABQAAAAVCAIAAADJt1n/AAAAKElEQVQ4EWPk5+RmIBcwkasRpG9UM4mhNxpgowFGMARGEwnBIEJVAAAdBgBNAZf+QAAAAABJRU5ErkJggg==
+    /// 图片文件名, 使用收到的图片文件名直接发送
+    /// 绝对路径，例如 file:///C:\\Users\Richard\Pictures\1.png，格式使用 file URI
+    /// 网络 URL，例如 http://i1.piimg.com/567571/fdd6e7b6d93f1ef0.jpg
+    /// Base64 编码，例如 base64://iVBORw0KGgoAAAANSUhEUgAAABQAAAAVCAIAAADJt1n/AAAAKElEQVQ4EWPk5+RmIBcwkasRpG9UM4mhNxpgowFGMARGEwnBIEJVAAAdBgBNAZf+QAAAAABJRU5ErkJggg==
     pub file: String,
 
-    // 图片类型, flash 表示闪照, 无此参数表示普通图片
+    /// 图片类型, flash 表示闪照, 无此参数表示普通图片
     #[serde(skip_serializing_if = "Option::is_none")]
     pub r#type: Option<String>,
 
-    // 发: 自定义图片预览信息
+    /// 发: 自定义图片预览信息
     #[serde(skip_serializing_if = "Option::is_none")]
     #[serde(default)]
     pub summary: Option<String>,
 
-    // 收
-    // 图片 URL
+    /// 收
+    /// 图片 URL
     #[serde(skip_serializing_if = "Option::is_none")]
     pub url: Option<String>,
 
-    // 发
-    // 可选0 1, 只在通过网络 URL 发送时有效, 表示是否使用已缓存的文件, 默认 1
+    /// 发
+    /// 可选0 1, 只在通过网络 URL 发送时有效, 表示是否使用已缓存的文件, 默认 1
     #[serde(skip_serializing_if = "Option::is_none")]
     pub cache: Option<u8>,
 
-    // 发
-    // 可选0 1, 只在通过网络 URL 发送时有效，表示是否通过代理下载文件（需通过环境变量或配置文件配置代理），默认 1
+    /// 发
+    /// 可选0 1, 只在通过网络 URL 发送时有效，表示是否通过代理下载文件（需通过环境变量或配置文件配置代理），默认 1
     #[serde(skip_serializing_if = "Option::is_none")]
     pub proxy: Option<u8>,
 
-    // 发
-    // 只在通过网络 URL 发送时有效，单位秒，表示下载网络文件的超时时间，默认不超时
+    /// 发
+    /// 只在通过网络 URL 发送时有效，单位秒，表示下载网络文件的超时时间，默认不超时
     #[serde(skip_serializing_if = "Option::is_none")]
     pub timeout: Option<u32>,
 }
 
 #[derive(Serialize, Deserialize, Debug, Clone, PartialEq, Eq)]
 pub struct RecordData {
-    // 语音文件名, 使用收到的语音文件名直接发送
-    // 以下为来自图片消息段的参考
-    // 绝对路径，例如 file:///C:\\Users\Richard\Pictures\1.png，格式使用 file URI
-    // 网络 URL，例如 http://i1.piimg.com/567571/fdd6e7b6d93f1ef0.jpg
-    // Base64 编码，例如 base64://iVBORw0KGgoAAAANSUhEUgAAABQAAAAVCAIAAADJt1n/AAAAKElEQVQ4EWPk5+RmIBcwkasRpG9UM4mhNxpgowFGMARGEwnBIEJVAAAdBgBNAZf+QAAAAABJRU5ErkJggg==
+    /// 语音文件名, 使用收到的语音文件名直接发送
+    /// 以下为来自图片消息段的参考
+    /// 绝对路径，例如 file:///C:\\Users\Richard\Pictures\1.png，格式使用 file URI
+    /// 网络 URL，例如 http://i1.piimg.com/567571/fdd6e7b6d93f1ef0.jpg
+    /// Base64 编码，例如 base64://iVBORw0KGgoAAAANSUhEUgAAABQAAAAVCAIAAADJt1n/AAAAKElEQVQ4EWPk5+RmIBcwkasRpG9UM4mhNxpgowFGMARGEwnBIEJVAAAdBgBNAZf+QAAAAABJRU5ErkJggg==
     pub file: String,
 
-    // 发送时可选，默认 0，设置为 1 表示变声
+    /// 发送时可选，默认 0，设置为 1 表示变声
     #[serde(skip_serializing_if = "Option::is_none")]
     pub magic: Option<u8>,
 
-    // 收
-    // 语音 URL
+    /// 收
+    /// 语音 URL
     #[serde(skip_serializing_if = "Option::is_none")]
     pub url: Option<String>,
 
-    // 发
-    // 只在通过网络 URL 发送时有效，表示是否使用已缓存的文件，默认 1
+    /// 发
+    /// 只在通过网络 URL 发送时有效，表示是否使用已缓存的文件，默认 1
     #[serde(skip_serializing_if = "Option::is_none")]
     pub cache: Option<u8>,
 
-    // 发
-    // 只在通过网络 URL 发送时有效，表示是否通过代理下载文件（需通过环境变量或配置文件配置代理），默认 1
+    /// 发
+    /// 只在通过网络 URL 发送时有效，表示是否通过代理下载文件（需通过环境变量或配置文件配置代理），默认 1
     #[serde(skip_serializing_if = "Option::is_none")]
     pub proxy: Option<u8>,
 
-    // 发
-    // 只在通过网络 URL 发送时有效，单位秒，表示下载网络文件的超时时间 ，默认不超时
+    /// 发
+    /// 只在通过网络 URL 发送时有效，单位秒，表示下载网络文件的超时时间 ，默认不超时
     #[serde(skip_serializing_if = "Option::is_none")]
     pub timeout: Option<u32>,
 }
 
 #[derive(Serialize, Deserialize, Debug, Clone, PartialEq, Eq)]
 pub struct VideoData {
-    // 视频文件名, 使用收到的视频文件名直接发送
-    // 以下为来自图片消息段的参考
-    // 绝对路径，例如 file:///C:\\Users\Richard\Pictures\1.png，格式使用 file URI
-    // 网络 URL，例如 http://i1.piimg.com/567571/fdd6e7b6d93f1ef0.jpg
-    // Base64 编码，例如 base64://iVBORw0KGgoAAAANSUhEUgAAABQAAAAVCAIAAADJt1n/AAAAKElEQVQ4EWPk5+RmIBcwkasRpG9UM4mhNxpgowFGMARGEwnBIEJVAAAdBgBNAZf+QAAAAABJRU5ErkJggg==
+    /// 视频文件名, 使用收到的视频文件名直接发送
+    /// 以下为来自图片消息段的参考
+    /// 绝对路径，例如 file:///C:\\Users\Richard\Pictures\1.png，格式使用 file URI
+    /// 网络 URL，例如 http://i1.piimg.com/567571/fdd6e7b6d93f1ef0.jpg
+    /// Base64 编码，例如 base64://iVBORw0KGgoAAAANSUhEUgAAABQAAAAVCAIAAADJt1n/AAAAKElEQVQ4EWPk5+RmIBcwkasRpG9UM4mhNxpgowFGMARGEwnBIEJVAAAdBgBNAZf+QAAAAABJRU5ErkJggg==
     pub file: String,
 
-    // 收
-    // 视频 URL
+    /// 收
+    /// 视频 URL
     #[serde(skip_serializing_if = "Option::is_none")]
     pub url: Option<String>,
 
-    // 发
-    // 只在通过网络 URL 发送时有效，表示是否使用已缓存的文件，默认 1
+    /// 发
+    /// 只在通过网络 URL 发送时有效，表示是否使用已缓存的文件，默认 1
     #[serde(skip_serializing_if = "Option::is_none")]
     pub cache: Option<u8>,
 
-    // 发
-    // 只在通过网络 URL 发送时有效，表示是否通过代理下载文件（需通过环境变量或配置文件配置代理），默认 1
+    /// 发
+    /// 只在通过网络 URL 发送时有效，表示是否通过代理下载文件（需通过环境变量或配置文件配置代理），默认 1
     #[serde(skip_serializing_if = "Option::is_none")]
     pub proxy: Option<u8>,
 
-    // 发
-    // 只在通过网络 URL 发送时有效，单位秒，表示下载网络文件的超时时间 ，默认不超时
+    /// 发
+    /// 只在通过网络 URL 发送时有效，单位秒，表示下载网络文件的超时时间 ，默认不超时
     #[serde(skip_serializing_if = "Option::is_none")]
     pub timeout: Option<u32>,
 }
 
 #[derive(Serialize, Deserialize, Debug, Clone, PartialEq, Eq)]
 pub struct AtData {
-    // @的 QQ 号，all 表示全体成员
+    /// @的 QQ 号，all 表示全体成员
     pub qq: String,
 }
 
 #[derive(Serialize, Deserialize, Debug, Clone, PartialEq, Eq)]
 pub struct PokeData {
-    // 类型，见 Mirai 的 PokeMessage 类
+    /// 类型，见 Mirai 的 PokeMessage 类
     pub r#type: String,
-    // ID
+    /// ID
     pub id: String,
 }
 
 #[derive(Serialize, Deserialize, Debug, Clone, PartialEq, Eq)]
 pub struct AnonymousData {
-    // 可选，表示无法匿名时是否继续发送
+    /// 可选，表示无法匿名时是否继续发送
     #[serde(skip_serializing_if = "Option::is_none")]
     pub ignore: Option<u8>,
 }
 
 #[derive(Serialize, Deserialize, Debug, Clone, PartialEq, Eq)]
 pub struct ShareData {
-    // URL
+    /// URL
     pub url: String,
-    // 标题
+    /// 标题
     pub title: String,
-    // 发送时可选，内容描述
+    /// 发送时可选，内容描述
     #[serde(skip_serializing_if = "Option::is_none")]
     pub content: Option<String>,
-    // 发送时可选，图片 URL
+    /// 发送时可选，图片 URL
     #[serde(skip_serializing_if = "Option::is_none")]
     pub image: Option<String>,
 }
@@ -523,55 +526,55 @@ pub enum ContactType {
 
 #[derive(Serialize, Deserialize, Debug, Clone, PartialEq, Eq)]
 pub struct ContactData {
-    // group 或 qq
+    /// group 或 qq
     pub r#type: ContactType,
-    // 被推荐人的 QQ 号或被推荐群的群号
+    /// 被推荐人的 QQ 号或被推荐群的群号
     pub id: String,
 }
 
 #[derive(Serialize, Deserialize, Debug, Clone, PartialEq, Eq)]
 pub struct LocationData {
-    // 纬度
+    /// 纬度
     pub lat: String,
-    // 经度
+    /// 经度
     pub lon: String,
-    // 发送时可选，标题
+    /// 发送时可选，标题
     #[serde(skip_serializing_if = "Option::is_none")]
     pub title: Option<String>,
-    // 发送时可选，内容描述
+    /// 发送时可选，内容描述
     #[serde(skip_serializing_if = "Option::is_none")]
     pub content: Option<String>,
 }
 
 #[derive(Serialize, Deserialize, Debug, Clone, PartialEq, Eq)]
 pub struct MusicData {
-    // 分别表示使用 QQ 音乐、网易云音乐、虾米音乐
+    /// 分别表示使用 QQ 音乐、网易云音乐、虾米音乐
     pub r#type: String,
-    // 歌曲 ID
+    /// 歌曲 ID
     pub id: String,
 }
 
 #[derive(Serialize, Deserialize, Debug, Clone, PartialEq, Eq)]
 pub struct CustomMusicData {
-    // 表示音乐自定义分享
+    /// 表示音乐自定义分享
     pub r#type: String,
-    // 点击后跳转目标 URL
+    /// 点击后跳转目标 URL
     pub url: String,
-    // 音乐 URL
+    /// 音乐 URL
     pub audio: String,
-    // 标题
+    /// 标题
     pub title: String,
-    // 发送时可选，内容描述
+    /// 发送时可选，内容描述
     #[serde(skip_serializing_if = "Option::is_none")]
     pub content: Option<String>,
-    // 发送时可选，图片 URL
+    /// 发送时可选，图片 URL
     #[serde(skip_serializing_if = "Option::is_none")]
     pub image: Option<String>,
 }
 
 #[derive(Serialize, Deserialize, Debug, Clone, PartialEq, Eq)]
 pub struct ReplyData {
-    // 回复时引用的消息 ID
+    /// 回复时引用的消息 ID
     pub id: String,
 }
 
@@ -580,40 +583,40 @@ pub struct ForwardData {
     pub id: String,
 }
 
-// 合并转发节点
+/// 合并转发节点
 #[derive(Serialize, Deserialize, Debug, Clone, PartialEq, Eq)]
 pub struct NodeData {
-    // 转发的消息 ID
+    /// 转发的消息 ID
     pub id: String,
 }
 
-// 自定义合并转发节点
-// 非obv11定义，而是适用于lagrand/gocq/llonebot/NapCat
+/// 自定义合并转发节点
+/// 非obv11定义，而是适用于lagrand/gocq/llonebot/NapCat
 #[derive(Serialize, Deserialize, Debug, Clone, PartialEq, Eq)]
 pub struct CustomNodeData {
-    // 自定义昵称(已失效)
+    /// 自定义昵称(已失效)
     pub name: Option<String>,
-    // 自定义qq号(已失效)
+    /// 自定义qq号(已失效)
     pub uin: Option<i64>,
-    // 自定义内容
+    /// 自定义内容
     pub content: Vec<MessageSegment>,
 }
 
 #[derive(Serialize, Deserialize, Debug, Clone, PartialEq, Eq)]
 pub struct XmlData {
-    // XML 内容
+    /// XML 内容
     pub data: String,
 }
 
 #[derive(Serialize, Deserialize, Debug, Clone, PartialEq, Eq)]
 pub struct JsonData {
-    // JSON 内容
+    /// JSON 内容
     pub data: String,
 }
 
-// onebot_v11某些变体的实现，如llonebot/NapCat
+/// onebot_v11某些变体的实现，如llonebot/NapCat
 #[derive(Serialize, Deserialize, Debug, Clone, PartialEq, Eq)]
-pub struct MfaceData {
+pub struct MFaceData {
     pub summary: String,
     pub url: String,
     pub emoji_id: String,
@@ -621,29 +624,29 @@ pub struct MfaceData {
     pub key: String,
 }
 
-// onebot_v11某些变体的实现，如llonebot/NapCat
+/// onebot_v11某些变体的实现，如llonebot/NapCat
 #[derive(Serialize, Deserialize, Debug, Clone, PartialEq, Eq)]
 pub struct File {
-    // 收: 文件名称 发： 文件路径
+    /// 收: 文件名称 发： 文件路径
     pub file: String,
-    // 发: 自定义文件名称
+    /// 发: 自定义文件名称
     #[serde(skip_serializing_if = "Option::is_none")]
     #[serde(default)]
     pub name: Option<String>,
-    // 收
-    // 文件路径
+    /// 收
+    /// 文件路径
     #[serde(skip_serializing)]
     pub path: String,
-    // 收
-    // 文件 URL
+    /// 收
+    /// 文件 URL
     #[serde(skip_serializing)]
     pub url: Option<String>,
-    // 收
-    // 文件 ID
+    /// 收
+    /// 文件 ID
     #[serde(skip_serializing)]
     pub file_id: String,
-    // 收
-    // 文件大小
+    /// 收
+    /// 文件大小
     #[serde(skip_serializing)]
     pub file_size: String,
 }


### PR DESCRIPTION
这是一个简单的更改：

1. 重构了文档字符串，部分文档字符串被写作了普通注释`//`而不是正确的文档字符串`///`；
2. 修复了一些拼写错误；
3. 新增了构建测试的持续集成（虽然看起来没有测试用例）。